### PR TITLE
Fixed regession around typing on the settings page function

### DIFF
--- a/docker.versions.plg
+++ b/docker.versions.plg
@@ -6,12 +6,15 @@
 <!ENTITY launch "Settings/docker.versions">
 <!ENTITY plugdir "/usr/local/emhttp/plugins/&name;">
 <!ENTITY pluginURL "https://raw.githubusercontent.com/&github;/main/&name;.plg">
-<!ENTITY version "2024.09.30">
-<!ENTITY md5 "bb529d26d3718c365dd85415d819586b">
+<!ENTITY version "2024.10.01">
+<!ENTITY md5 "b99d6d966301580ff89b715e3828474e">
 ]>
 
 <PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" pluginURL="&pluginURL;" min="6.12.3">
     <CHANGES>
+###2024.10.01
+- Fix type issue on settings page function
+
 ###2024.09.30
 - Fix regression around missing open containers image date
 - Fix fallback to secondary when primary source is missing

--- a/src/docker.versions/usr/local/emhttp/plugins/docker.versions/server/config/GithubToken.php
+++ b/src/docker.versions/usr/local/emhttp/plugins/docker.versions/server/config/GithubToken.php
@@ -10,7 +10,7 @@ class GithubToken
      * Save the GitHub token to a file.
      * @return string
      */
-    static function formSubmit(): string
+    static function formSubmit(): string|null
     {
         if ($_SERVER["REQUEST_METHOD"] == "POST") {
             // Get the GitHub token from the form input
@@ -27,7 +27,6 @@ class GithubToken
         }
         return null;
     }
-
 
     /**
      * Get the GitHub token from the config file.


### PR DESCRIPTION
#3 

This pull request includes updates to the `docker.versions.plg` file and improvements to the `GithubToken` class in `GithubToken.php`. The most significant changes involve updating the plugin version and fixing a type issue on the settings page, as well as enhancing the `formSubmit` method to allow a nullable return type.

### Plugin Version Update and Bug Fixes:
* [`docker.versions.plg`](diffhunk://#diff-ef716da5709824433c83e4773b3f09693d46357ea22a1e4cc9cdb96c7431cad0L9-R17): Updated the plugin version to `2024.10.01` and fixed a type issue on the settings page function.

### Code Improvements:
* [`GithubToken.php`](diffhunk://#diff-9be1e590c086ce091ae6128bfce98d73e2408495f81992036fd8dbf9c3e808e8L13-R13): Modified the `formSubmit` method in the `GithubToken` class to return `string|null` instead of just `string`.
* [`GithubToken.php`](diffhunk://#diff-9be1e590c086ce091ae6128bfce98d73e2408495f81992036fd8dbf9c3e808e8L31): Removed an unnecessary blank line in the `formSubmit` method.