### PR TITLE
Feature/add new source commit, support multiple sources, various code refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,44 +8,88 @@ At the moment github is only supported, happy to support more just need some goo
 
 It should be noted the quality of the changelog is dependent on whatever is posted on the release by the maintainers.
 
-It is highly suggested to generate a github token, this can be set in the settings page for docker.verions and has instructions on this page.
+It is highly suggested to generate a github token, this can be set in the settings page for docker.versions and has instructions on this page.
 
-For the best experience images need the following labels;
+## Flow of release checks
 
-* `org.opencontainers.image.created`
-* `org.opencontainers.image.source`
-* `org.opencontainers.image.version`
-* `docker.versions.source`
+When a container image is checked for release changes the following steps of things occur
 
-If `org.opencontainers.image.source` is missing it will;
+* check for opencontainers labels
+* If org.opencontainers.image.source is found
+  * If docker.versions.imageSourceType is found it will only check that type below
+  * Otherwise If the url contains the conditions for a changelog file it will attempt to parse it. note url must contain `.md` or `changelog`
+    * this way is experimental and assuming each "version" is denoted with a some sort of date field (feel free to raise issues if you notice a changelog that doesn't work and i can try to see if more flows can be supported)
+  * If still nothing it will attempt to check the last 100 github releases
+  * If still nothing it will attempt to check the last 100 github tags
+    * Note: using tags slows things down alot due to being unable to get the tag message without secondary curl requests
+  * If still nothing it fallback to the last 100 github commit messages
+* If docker.versions.source is found the above will be followed to collect all secondary releases
+* It will then use the org.opencontainers.image.version and org.opencontainers.image.created to filter down the releases to hopefully be the current updatable context
+  * It will also attempt to hide duplicated changelogs
+  * If the org.opencontainers.image.created is not found it will then attempt to subset to the last 6 months of releases
+  * If nothing then it will fallback to displaying everything
 
-* check if its template has a project configured, if so use that as a release base.
-* Otherwise do its best to guess the github repo based on the image registry.
+## Container Labels
 
-If `org.opencontainers.image.created` is missing it will simply display all.
+For the best experience images try to add following labels;
 
-If `org.opencontainers.image.version` is present this will be used to subset images to preRelease only i.e dev/beta/alpha ect.
+| Label                             | Description                                                                                                                              |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| org.opencontainers.image.created  | If missing it will attempt to list the last 6 months of releases found based on type                                                     |
+|                                   | otherwise falls back to all found releases                                                                                               |
+|                                   |                                                                                                                                          |
+| org.opencontainers.image.source   | Attempts to use this as the source                                                                                                       |
+|                                   | if missing checks the unraid template for the image registry and attempts a best guess matchup to a github repo                          |
+|                                   |                                                                                                                                          |
+| org.opencontainers.image.version  | If present will be used as part of the subsetting of releases to be shown                                                                |
+|                                   | i.e if contains beta then tries to show other beta releases, vice versa exclude them if not found                                        |
+|                                   | Also uses the version to try and filter when a repo may manage multiple projects                                                         |
+|                                   |                                                                                                                                          |
+| docker.versions.imageSourceType   | If provided this will be used as the only place to check for releases                                                                    |
+|                                   | This can be useful if you want to avoid hitting github for relevant endpoints, or prefer a fallback                                      |
+|                                   | Applies to org.opencontainers.image.source                                                                                               |
+|                                   | Options include;                                                                                                                         |
+|                                   | changelogs - when set will only be parsed as a changelog, note url must contain `.md` or `changelog`                                     |
+|                                   | releases - when set will only parse releases                                                                                             |
+|                                   | tags - when set will only parse tags                                                                                                     |
+|                                   | commits - when set will only parse commits                                                                                               |
+|                                   | disable - when set it will just skip source entirely                                                                                     |
+|                                   |                                                                                                                                          |
+| docker.versions.source            | Same as org.opencontainers.image.source                                                                                                  |
+|                                   | but is used to collect a secondary list of releases                                                                                      |
+|                                   | If the primary list fails to find any items then this secondary list is used as the primary                                              |
+|                                   |                                                                                                                                          |
+|                                   | This is useful When the container is hosted external to the actual program source                                                        |
+|                                   | example if org.opencontainers.image.source is `https://github.com/linuxserver/docker-sonarr`                                             |
+|                                   | you can also provide docker.versions.source as`https://github.com/Sonarr/Sonarr`                                                         |
+|                                   | it will do its best to match up a secondary change with a primary change                                                                 |
+|                                   |                                                                                                                                          |
+|                                   | At this time only one secondary source is allowed, until i find the need for multiple it will stay this way                              |
+|                                   | feel free to raise an issue with the context that makes you think you need this logic and i can use it as a test case to implement it :) |
+|                                   |                                                                                                                                          |
+| docker.versions.sourceType        | Same as docker.versions.imageSourceType                                                                                                  |
+|                                   | but applies to docker.versions.source                                                                                                    |
+|                                   |                                                                                                                                          |
+| docker.versions.tagIgnorePrefixes | csv of terms used exclude certain releases                                                                                               |
+|                                   | i.e if you provide `apple,banana` if either of these are found in the title of the release it will not be shown                          |
 
-If no releases are found it will fall back to trying to pull the tags;
+If a container is missing opencontainers labels suggest to the maintainer to add them
+an easy way to implement the labels is via this [github action](https://github.com/docker/metadata-action)
+i.e
 
-## docker.versions.source
-
-I also suggest you provide a secondary source via `docker.versions.source` label on your template.
-
-When the container is hosted external to the actual program source, This will be used as a secondary source to show changesets for example if the image is `https://github.com/linuxserver/docker-sonarr` you can also provide `https://github.com/Sonarr/Sonarr` and it will do its best to match up a secondary change with a primary change.
-
-At this time only one secondary source is allowed, until i find the need for multiple it will stay this way, free free top raise and issue with the context that makes you think you need this logic and i can use it as a test case to implement it
-
-You can also provide a changelog file url to `docker.versions.source` as long as it ends in `.md` or contains the word `changelog` it should attempt to use it work.
-NOTE: this way is experimental and assuming each "version" is denoted with a some sort of date field (feel free to raise issues if you notice a changelog that doesn't work and i can try to see if more flows can be supported)
-
-If no releases are found for primary source, the secondary source will be used as the primary source instead.
-
-If no primary found secondary will work as if its the primary.
-
-## docker.versions.tagIgnorePrefixes
-
-If you want to exclude certain releases simply use the following label `docker.versions.tagIgnorePrefixes`, this will be used to subset what is displayed on the changelogs window. This is useful when a repo contains changelogs for multiple contexts instead of just one
+```yml
+-   name: Docker meta
+    id: meta
+    uses: docker/metadata-action@v5
+    with:
+        images: ghcr.io/${{ github.repository }}:latest
+-   name: Build and push
+    uses: docker/build-push-action@v4
+    with:
+        push: true
+        tags: ghcr.io/${{ github.repository }}:latest
+        labels: ${{ steps.meta.outputs.labels }}
+```
 
 below are a few examples of what can happen
 
@@ -66,3 +110,14 @@ below are a few examples of what can happen
 
 * when duplicated changelogs are detected
 ![Duplicated releases](images/duplicated.png)
+
+<!-- TODO: -->
+Add label to force primary to use a certain source i.e docker.versions.sourceType
+add one for secondary too
+if set will only look at type for changes
+will save from having to hit all locations OR avoid using one when they are no lnger used
+i.e maybe an app once used releases but now tags are more accurate
+values below are what is expected
+public const ALLOWED_TYPES = ['release', 'tag', 'changelog', 'commit'];
+
+If we were to filter by date after each check it might avoid the issue where no release get found for the first found type

--- a/README.md
+++ b/README.md
@@ -33,45 +33,45 @@ When a container image is checked for release changes the following steps of thi
 
 For the best experience images try to add following labels;
 
-| Label                             | Description                                                                                                                              |
-| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| org.opencontainers.image.created  | If missing it will attempt to list the last 6 months of releases found based on type                                                     |
-|                                   | otherwise falls back to all found releases                                                                                               |
-|                                   |                                                                                                                                          |
-| org.opencontainers.image.source   | Attempts to use this as the source                                                                                                       |
-|                                   | if missing checks the unraid template for the image registry and attempts a best guess matchup to a github repo                          |
-|                                   |                                                                                                                                          |
-| org.opencontainers.image.version  | If present will be used as part of the subsetting of releases to be shown                                                                |
-|                                   | i.e if contains beta then tries to show other beta releases, vice versa exclude them if not found                                        |
-|                                   | Also uses the version to try and filter when a repo may manage multiple projects                                                         |
-|                                   |                                                                                                                                          |
-| docker.versions.imageSourceType   | If provided this will be used as the only place to check for releases                                                                    |
-|                                   | This can be useful if you want to avoid hitting github for relevant endpoints, or prefer a fallback                                      |
-|                                   | Applies to org.opencontainers.image.source                                                                                               |
-|                                   | Options include;                                                                                                                         |
-|                                   | changelogs - when set will only be parsed as a changelog, note url must contain `.md` or `changelog`                                     |
-|                                   | releases - when set will only parse releases                                                                                             |
-|                                   | tags - when set will only parse tags                                                                                                     |
-|                                   | commits - when set will only parse commits                                                                                               |
-|                                   | disable - when set it will just skip source entirely                                                                                     |
-|                                   |                                                                                                                                          |
-| docker.versions.source            | Same as org.opencontainers.image.source                                                                                                  |
-|                                   | but is used to collect a secondary list of releases                                                                                      |
-|                                   | If the primary list fails to find any items then this secondary list is used as the primary                                              |
-|                                   |                                                                                                                                          |
-|                                   | This is useful When the container is hosted external to the actual program source                                                        |
-|                                   | example if org.opencontainers.image.source is `https://github.com/linuxserver/docker-sonarr`                                             |
-|                                   | you can also provide docker.versions.source as`https://github.com/Sonarr/Sonarr`                                                         |
-|                                   | it will do its best to match up a secondary change with a primary change                                                                 |
-|                                   |                                                                                                                                          |
-|                                   | At this time only one secondary source is allowed, until i find the need for multiple it will stay this way                              |
-|                                   | feel free to raise an issue with the context that makes you think you need this logic and i can use it as a test case to implement it :) |
-|                                   |                                                                                                                                          |
-| docker.versions.sourceType        | Same as docker.versions.imageSourceType                                                                                                  |
-|                                   | but applies to docker.versions.source                                                                                                    |
-|                                   |                                                                                                                                          |
-| docker.versions.tagIgnorePrefixes | csv of terms used exclude certain releases                                                                                               |
-|                                   | i.e if you provide `apple,banana` if either of these are found in the title of the release it will not be shown                          |
+| Label                             | Description                                                                                                     |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| org.opencontainers.image.created  | If missing it will attempt to list the last 6 months of releases found based on type                            |
+|                                   | otherwise falls back to all found releases                                                                      |
+|                                   |                                                                                                                 |
+| org.opencontainers.image.source   | Attempts to use this as the source                                                                              |
+|                                   | if missing checks the unraid template for the image registry and attempts a best guess matchup to a github repo |
+|                                   |                                                                                                                 |
+| org.opencontainers.image.version  | If present will be used as part of the subsetting of releases to be shown                                       |
+|                                   | i.e if contains beta then tries to show other beta releases, vice versa exclude them if not found               |
+|                                   | Also uses the version to try and filter when a repo may manage multiple projects                                |
+|                                   |                                                                                                                 |
+| docker.versions.imageSourceType   | If provided this will be used as the only place to check for releases                                           |
+|                                   | This can be useful if you want to avoid hitting github for relevant endpoints, or prefer a fallback             |
+|                                   | Applies to org.opencontainers.image.source                                                                      |
+|                                   | Options include;                                                                                                |
+|                                   | changelogs - when set will only be parsed as a changelog, note url must contain `.md` or `changelog`            |
+|                                   | releases - when set will only parse releases                                                                    |
+|                                   | tags - when set will only parse tags                                                                            |
+|                                   | commits - when set will only parse commits                                                                      |
+|                                   | disable - when set it will just skip source entirely                                                            |
+|                                   |                                                                                                                 |
+| docker.versions.source            | Same as org.opencontainers.image.source                                                                         |
+|                                   | but is used to collect a secondary list of releases                                                             |
+|                                   | If the primary list fails to find any items then this secondary list is used as the primary                     |
+|                                   |                                                                                                                 |
+|                                   | This is useful When the container is hosted external to the actual program source                               |
+|                                   | example if org.opencontainers.image.source is `https://github.com/linuxserver/docker-sonarr`                    |
+|                                   | you can also provide docker.versions.source as`https://github.com/Sonarr/Sonarr`                                |
+|                                   | it will do its best to match up a secondary change with a primary change                                        |
+|                                   |                                                                                                                 |
+|                                   | You can provide this as csv to add additional sources  (Experimental)                                           |
+|                                   |                                                                                                                 |
+| docker.versions.sourceType        | Same as docker.versions.imageSourceType                                                                         |
+|                                   | but applies to docker.versions.source                                                                           |
+|                                   | This also works in the same way and is expected to be provided as csv lining up to the source its applicable to |
+|                                   |                                                                                                                 |
+| docker.versions.tagIgnorePrefixes | csv of terms used exclude certain releases                                                                      |
+|                                   | i.e if you provide `apple,banana` if either of these are found in the title of the release it will not be shown |
 
 If a container is missing opencontainers labels suggest to the maintainer to add them
 an easy way to implement the labels is via this [github action](https://github.com/docker/metadata-action)
@@ -110,14 +110,3 @@ below are a few examples of what can happen
 
 * when duplicated changelogs are detected
 ![Duplicated releases](images/duplicated.png)
-
-<!-- TODO: -->
-Add label to force primary to use a certain source i.e docker.versions.sourceType
-add one for secondary too
-if set will only look at type for changes
-will save from having to hit all locations OR avoid using one when they are no lnger used
-i.e maybe an app once used releases but now tags are more accurate
-values below are what is expected
-public const ALLOWED_TYPES = ['release', 'tag', 'changelog', 'commit'];
-
-If we were to filter by date after each check it might avoid the issue where no release get found for the first found type

--- a/docker.versions.plg
+++ b/docker.versions.plg
@@ -12,6 +12,12 @@
 
 <PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" pluginURL="&pluginURL;" min="6.12.3">
     <CHANGES>
+###2024.11.02
+- Changed all summaries to be open by default
+- Reworked readme
+- Added a new fallback of commit messages, falls back if no tags are found or is enforced via sourceType
+- Added new labels sourceType and imageSourceType, these are used enforce only parsing as a specific type instead of checking one by one
+- This can be useful to avoid extra api calls or enforce a specific type, i.e you might only care about commit message logs and tags takes too long.
 ###2024.10.31
 - Fix text wrapping so you dont need to scroll to the right to see long changelogs
 ###2024.10.02

--- a/docker.versions.plg
+++ b/docker.versions.plg
@@ -13,6 +13,7 @@
 <PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" pluginURL="&pluginURL;" min="6.12.3">
     <CHANGES>
 ###2024.11.02
+- Adjusted docker.versions.source to be a comma separated list
 - Changed all summaries to be open by default
 - Reworked readme
 - Added a new fallback of commit messages, falls back if no tags are found or is enforced via sourceType

--- a/src/docker.versions/usr/local/emhttp/plugins/docker.versions/server/models/Release.php
+++ b/src/docker.versions/usr/local/emhttp/plugins/docker.versions/server/models/Release.php
@@ -10,7 +10,7 @@ use DockerVersions\Helpers\Generic;
 
 class Release
 {
-    public const ALLOWED_TYPES = ['release', 'tag', 'changelog'];
+    public const ALLOWED_TYPES = ['release', 'tag', 'changelog', 'commit'];
     public string $type;
     public string $tagName;
 

--- a/src/docker.versions/usr/local/emhttp/plugins/docker.versions/server/services/Containers.php
+++ b/src/docker.versions/usr/local/emhttp/plugins/docker.versions/server/services/Containers.php
@@ -113,7 +113,7 @@ class Containers
 
                     Publish::message("<h3>Container: $container->name</h3>");
                     Publish::message("<h3>$currentImageSourceTag ($currentImageCreatedAt) ---->  {$firstRelease->tagName} ({$latestImageCreatedAt})</h3>");
-                    Publish::message("<a href=\"$releasesUrl\" target=\"blank\">Url for primary changelog information</a>");
+                    Publish::message("<a href=\"$releasesUrl\" target=\"blank\">Url for changelog information</a>");
                     if (!empty($allSecondaryReleases)) {
                         Publish::message("<br><a href=\"$secondaryReleases->releasesUrl\" target=\"blank\">Url for secondary changelog information</a>");
                     }
@@ -124,7 +124,7 @@ class Containers
 
                     foreach ($releases as $primaryRelease) {
                         $detailsChunks = [
-                            "<details style='text-wrap:wrap;' class='releasesInfo'>",
+                            "<details style='text-wrap:wrap;' class='releasesInfo' open>",
                             "<summary><a target=\"blank\" href=\"{$primaryRelease->htmlUrl}\">{$primaryRelease->tagName} ($primaryRelease->createdAt)</a></summary>",
                         ];
                         if (!empty($primaryRelease->extraReleases)) {
@@ -135,7 +135,7 @@ class Containers
                                 $detailsChunks = array_merge(
                                     $detailsChunks,
                                     [
-                                        "<details>",
+                                        "<details open>",
                                         "<summary>Duplicate changelogs</summary>"
                                     ],
                                     array_map(
@@ -152,7 +152,7 @@ class Containers
                         $detailsChunks = array_merge(
                             $detailsChunks,
                             [
-                                "<details>",
+                                "<details open>",
                                 "<summary>Changelog Notes</summary>",
                                 "<div>{$primaryRelease->getBody()}</div>",
                                 "</details>"
@@ -166,7 +166,7 @@ class Containers
                                 $detailsChunks = array_merge(
                                     $detailsChunks,
                                     [
-                                        "<details>",
+                                        "<details open>",
                                         "<summary>Secondary Source Changelogs</summary>"
                                     ],
                                 );
@@ -176,7 +176,7 @@ class Containers
                                         $detailsChunks = array_merge(
                                             $detailsChunks,
                                             [
-                                                "<details>",
+                                                "<details open>",
                                                 "<summary>Duplicate Secondary changelogs</summary>"
                                             ],
                                             array_map(
@@ -231,6 +231,7 @@ class Containers
      * @param Release[] $releases
      * @param string $date
      */
+    //  TODO: if we can ever get the a good fallback for createed date lets filterByRelease in organise and then we can improve the pull flow to fallback better
     private static function filterReleasesByDate(array $releases, string $date): array
     {
         $allFilteredReleases = array_filter($releases, function ($release) use ($date) {

--- a/src/docker.versions/usr/local/emhttp/plugins/docker.versions/server/services/Releases.php
+++ b/src/docker.versions/usr/local/emhttp/plugins/docker.versions/server/services/Releases.php
@@ -309,9 +309,13 @@ class Releases
             }, $groupedChangeLogs)
         );
 
-        if (!$this->hasReleases()) {
+
+        if ($this->hasReleases()) {
+            Publish::message("<li class='warnings'>Pulled to changelog for information for $this->repositorySource</li>");
+        } else {
             Publish::message("<li class='warnings'>No changelogs found! (<a href=\"$releasesUrl\" target=\"blank\">Changelogs</a>)</li>");
         }
+        $this->organiseReleases();
     }
 
     /**
@@ -319,9 +323,6 @@ class Releases
      */
     function pullReleases(): void
     {
-        if ($this->isChangelogUrl()) {
-            return;
-        }
         $releasesUrl = $this->githubURL() . "/releases?per_page=" . self::perPage;
         $this->releasesUrl = $releasesUrl;
 
@@ -345,23 +346,26 @@ class Releases
             );
         }, $releases);
 
-        if (!$this->hasReleases()) {
+        if ($this->hasReleases()) {
+            Publish::message("<li class='warnings'>Pulled last " . count($this->releases) . " releases for information for $this->repositorySource</li>");
+        } else {
             Publish::message("<li class='warnings'>No releases found! (<a href=\"$releasesUrl\" target=\"blank\">Releases</a>)</li>");
         }
+        $this->organiseReleases();
     }
     /**
      * Pull tags from the github API.
      */
     function pullTags(): void
     {
-        $tagsUrl = $this->githubURL() . "/tags?per_page=" . self::perPage;
-        $this->releasesUrl = $tagsUrl;
-        $tags = $this->makeReq($tagsUrl);
+        $url = $this->githubURL() . "/tags?per_page=" . self::perPage;
+        $this->releasesUrl = $url;
+        $tags = $this->makeReq($url);
 
         // $page = 1;
         // $tags = [];
         // do {
-        //     $tags = array_merge($tags, $this->makeReq("$tagsUrl&page=$page"));
+        //     $tags = array_merge($tags, $this->makeReq("$url&page=$page"));
         //     $page++;
         // } while (count($tags) % 100 == 0);
 
@@ -378,6 +382,14 @@ class Releases
                 false
             );
         }, $tags);
+
+        if ($this->hasReleases()) {
+            Publish::message("<li class='warnings'>Pulled last " . count($this->releases) . " tags for information for $this->repositorySource</li>");
+        } else {
+            Publish::message("<li class='warnings'>No tags found! (<a href=\"$url\" target=\"blank\">$url</a>)</li>");
+        }
+        $this->organiseReleases();
+    }
 
     /**
      * Pull commits from the github API.


### PR DESCRIPTION
This pull request includes significant updates to the `docker.versions` plugin, focusing on improving the handling of container image releases and the associated metadata. The changes include a major rework of the README for better clarity, updates to the plugin's XML and PHP files to support new labels and source types, and enhancements to the release fetching logic.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R92): Reworked the documentation to provide a clearer flow of release checks and added detailed descriptions for container labels.

### Plugin Configuration:
* [`docker.versions.plg`](diffhunk://#diff-ef716da5709824433c83e4773b3f09693d46357ea22a1e4cc9cdb96c7431cad0R15-R21): Updated the plugin configuration to support a comma-separated list for `docker.versions.source` and added new labels `sourceType` and `imageSourceType`.

### Code Enhancements:
* [`src/docker.versions/usr/local/emhttp/plugins/docker.versions/server/models/Container.php`](diffhunk://#diff-1d2364115058d4613ce43b7a6d0ae30496b544343805f9d1260a7b1c53aeb0d7L23-R69): Added new properties `sourceType` and `imageSourceType`, and refactored the constructor to process labels using a new private method `processLabels`.
* [`src/docker.versions/usr/local/emhttp/plugins/docker.versions/server/services/Containers.php`](diffhunk://#diff-f8550c908ae589d9bcf1b2876d1f629cdd0a2ef8011aa1f69dd4f2ec3a2e1a6bR40-R91): Refactored the release fetching logic into a new method `pullContainerReleases` and updated `getChangeLogs` to use this method for better modularity and readability. [[1]](diffhunk://#diff-f8550c908ae589d9bcf1b2876d1f629cdd0a2ef8011aa1f69dd4f2ec3a2e1a6bR40-R91) [[2]](diffhunk://#diff-f8550c908ae589d9bcf1b2876d1f629cdd0a2ef8011aa1f69dd4f2ec3a2e1a6bL51-R149)

### Additional Changes:
* [`src/docker.versions/usr/local/emhttp/plugins/docker.versions/server/models/Release.php`](diffhunk://#diff-3c338c216701bb31a74379f98d2ce1df81a5693ac8db70c7a49e878da49fac5dL13-R13): Expanded the allowed types to include 'commit' for more comprehensive release tracking.
* [`src/docker.versions/usr/local/emhttp/plugins/docker.versions/server/models/Container.php`](diffhunk://#diff-1d2364115058d4613ce43b7a6d0ae30496b544343805f9d1260a7b1c53aeb0d7L66-R81): Updated the type hint for `getRepositorySource` method to `array` for consistency.

These updates enhance the plugin's functionality by providing more flexible and detailed release tracking, improving documentation, and refactoring code for better maintainability.